### PR TITLE
Add prominent app banner to top of site

### DIFF
--- a/src/app/blogs/[slug]/page.tsx
+++ b/src/app/blogs/[slug]/page.tsx
@@ -38,7 +38,7 @@ export default async function PostPage({ params }: Params) {
   return (
     <>
       <StructuredData data={articleSchema} />
-      <main className="min-h-screen bg-background pt-10">
+      <main className="min-h-screen bg-background pt-24 lg:pt-28">
         {/* Hero Section with Gradient */}
         <div className="relative bg-gradient-to-b from-card/50 to-transparent border-b border-border/50">
           <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">

--- a/src/app/blogs/page.tsx
+++ b/src/app/blogs/page.tsx
@@ -29,7 +29,7 @@ export default async function BlogsPage() {
 
   return (
     <main className="min-h-screen">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 lg:py-20">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24 lg:py-28">
         {/* Header */}
         <div className="text-center mb-16">
           <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-primary/10 border border-primary/20 text-primary text-sm font-medium mb-6">

--- a/src/components/Navigation_v2.tsx
+++ b/src/components/Navigation_v2.tsx
@@ -16,9 +16,24 @@ function Navigation_v2() {
 
   return (
     <>
-    <div className="fixed top-0 left-0 right-0 w-full bg-background backdrop-blur border-b z-50">
-    <nav className="container mx-auto px-4 md:px-6" aria-label="Main navigation">
-        <div className="flex h-16 items-center justify-between">
+    <div className="fixed top-0 left-0 right-0 w-full z-50 flex flex-col">
+      {/* App Banner */}
+      <div className="bg-primary text-primary-foreground flex items-center justify-center gap-3 sm:gap-4 px-4 h-12 text-sm sm:text-base font-semibold shadow-md relative z-50">
+        <span className="text-center">Watch race livestreams and news</span>
+        <Link
+          href="https://apps.apple.com/in/app/nxtlap-race-scores-widgets/id6754256034"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex-shrink-0 bg-background text-primary hover:bg-muted px-4 py-1 rounded-full text-xs sm:text-sm font-bold transition-all shadow-sm flex items-center gap-1.5 hover:scale-105"
+        >
+          <Download size={14} className="sm:w-4 sm:h-4" />
+          Get App
+        </Link>
+      </div>
+
+      <div className="w-full bg-background backdrop-blur border-b">
+        <nav className="container mx-auto px-4 md:px-6" aria-label="Main navigation">
+          <div className="flex h-16 items-center justify-between">
           {/* Logo */}
           <Link
             href="/"
@@ -61,32 +76,20 @@ function Navigation_v2() {
             ))}
           </div>
 
-          {/* Desktop Right Side (App Button) */}
-          <div className="hidden md:flex items-center">
-            <Link
-              href="https://apps.apple.com/in/app/nxtlap-race-scores-widgets/id6754256034"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center gap-2 bg-primary hover:bg-primary/90 text-primary-foreground px-4 py-2 rounded-full text-xs font-medium transition-colors focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-4 shadow-sm"
-            >
-              <Download size={14} />
-              <span>Get App</span>
-            </Link>
-          </div>
-
           {/* Mobile Menu Button */}
           <div className="flex md:hidden">
             <Button variant="ghost" size="icon" onClick={toggleMobileMenu} aria-label="Toggle menu">
               {isMobileMenuOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
             </Button>
           </div>
-        </div>
-    </nav>
+          </div>
+        </nav>
+      </div>
     </div>
 
       {/* Mobile Menu Overlay */}
       {isMobileMenuOpen && (
-        <div className="fixed inset-0 top-[64px] z-40 md:hidden bg-background/95 backdrop-blur-sm animate-in slide-in-from-top-2">
+        <div className="fixed inset-0 top-[112px] z-40 md:hidden bg-background/95 backdrop-blur-sm animate-in slide-in-from-top-2">
           <div className="space-y-1 px-4 py-4">
             {navItems
              .filter(item => item.label !== "FAQs")

--- a/src/components/SeriesSelector.tsx
+++ b/src/components/SeriesSelector.tsx
@@ -51,7 +51,7 @@ export function SeriesSelector() {
   return (
     <div 
       className={cn(
-        "fixed top-16 left-0 right-0 w-full border-b bg-background overflow-x-auto no-scrollbar transition-transform duration-300 z-30",
+        "fixed top-[112px] left-0 right-0 w-full border-b bg-background overflow-x-auto no-scrollbar transition-transform duration-300 z-30",
         isVisible ? "translate-y-0" : "-translate-y-full"
       )}
     >

--- a/src/components/TwoPanelLayout.tsx
+++ b/src/components/TwoPanelLayout.tsx
@@ -10,7 +10,7 @@ export function TwoPanelLayout({
   rightPanel,
 }: TwoPanelLayoutProps) {
   return (
-    <div className="container mx-auto px-4 md:px-6 pb-6 md:pb-8 pt-36 md:pt-40">
+    <div className="container mx-auto px-4 md:px-6 pb-6 md:pb-8 pt-44 md:pt-48">
       <div className="grid grid-cols-1 lg:grid-cols-12 gap-6 xl:gap-8">
         {/* Center Panel - Main Content */}
         <main className="lg:col-span-9 xl:col-span-9 order-1 lg:order-1 space-y-6 min-h-[50vh]">


### PR DESCRIPTION
Added a new app promotion banner to the top of the site header in `Navigation_v2`, removed the duplicate 'Get App' button from the desktop nav row, and offset the sticky/fixed elements (SeriesSelector and mobile nav menu) and page paddings (`TwoPanelLayout` and `blog` pages) to correctly adapt to the new header height.

---
*PR created automatically by Jules for task [1903787817482727505](https://jules.google.com/task/1903787817482727505) started by @thevaidik*